### PR TITLE
Verify user on championship submission

### DIFF
--- a/src/routes/(public)/championship/submission/+page.server.ts
+++ b/src/routes/(public)/championship/submission/+page.server.ts
@@ -6,10 +6,26 @@ export const load = (async () => {
 }) satisfies PageServerLoad;
 
 export const actions: Actions = {
-  default: async ({ request, locals: { supabase } }) => {
+  default: async ({ request, locals }) => {
+    const { supabase, user } = locals;
+    if (!user) {
+      throw error(401, "Not authenticated");
+    }
+
     const formData = await request.formData();
-    const username = formData.get("username") as string;
+    const providedUsername = formData.get("username") as string;
     const submission = formData.get("submission");
+
+    const { data: profiles, error: profileError } = await supabase
+      .from("profiles")
+      .select("username")
+      .eq("user_id", user.id);
+
+    if (profileError) throw error(500, profileError.message);
+    const username = profiles?.[0]?.username;
+    if (!username || username !== providedUsername) {
+      throw error(401, "Unauthorized");
+    }
 
     if (!(submission instanceof File)) {
       throw error(400, "Submission is not a file");


### PR DESCRIPTION
## Summary
- verify the user is authenticated in championship submission action
- fetch the username from the profiles table
- block uploads if the form username doesn't match the authenticated user

## Testing
- `npm test` *(fails: m.ago_lost_nuthatch_belong is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_685e57a88578832cb1c532bd1efaab6b