### PR TITLE
Fix submission profile check

### DIFF
--- a/src/routes/(public)/championship/submission/+page.svelte
+++ b/src/routes/(public)/championship/submission/+page.svelte
@@ -15,7 +15,9 @@
       .eq("user_id", user?.id);
 
     if (profileErr) throw error(500, profileErr.message);
-    username = profiles[0].username;
+    if (profiles && profiles.length > 0) {
+      username = profiles[0].username;
+    }
     return { username };
   });
 </script>
@@ -45,7 +47,7 @@
     />
     <button class="btn" type="submit" disabled={!username}>Submit</button>
     {#if !username}
-      <p class="text-error">You must be logged in to submit.</p>
+      <p class="text-error">You must create a profile or log in to submit.</p>
     {/if}
   </form>
 </section>


### PR DESCRIPTION
## Summary
- avoid throwing error when no user profile exists on submission page
- advise visitors to create a profile or log in before submitting

## Testing
- `npm test` *(fails: m.ago_lost_nuthatch_belong is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_685e57a6df78832c96446b12939c0d7a