### PR TITLE
Fix: only make approved cubes show in the cubes explore page

### DIFF
--- a/src/routes/(public)/explore/cubes/+page.svelte
+++ b/src/routes/(public)/explore/cubes/+page.svelte
@@ -59,7 +59,7 @@
     ]) => {
       return cubes
         .filter((c) => c.version_type === "Base")
-        .filter((c) => c.approved === true)
+        .filter((c) => c.status === "Approved")
         .filter((c) => {
           const cubeYear = new Date(c.release_date).getFullYear();
           return (


### PR DESCRIPTION
This pull request fixes the bug where the old check remained active, causing all cubes to be hidden on the Explore page.