### PR TITLE
Add client error reporter

### DIFF
--- a/src/lib/components/misc/clientErrorReporter.svelte
+++ b/src/lib/components/misc/clientErrorReporter.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { toast } from 'svelte-sonner';
+
+  function showToast(message: string) {
+    toast.error('A client error occurred', {
+      description: 'Click to report the bug',
+      action: {
+        label: 'Report',
+        onClick: () => {
+          const url = `/report?error=${encodeURIComponent(message)}`;
+          window.location.href = url;
+        }
+      }
+    });
+  }
+
+  onMount(() => {
+    const handleError = (event: ErrorEvent) => {
+      const msg = event.error?.message || event.message;
+      showToast(msg);
+    };
+    const handleRejection = (event: PromiseRejectionEvent) => {
+      const reason = event.reason as any;
+      const msg = reason?.message ?? String(reason);
+      showToast(msg);
+    };
+
+    window.addEventListener('error', handleError);
+    window.addEventListener('unhandledrejection', handleRejection);
+
+    return () => {
+      window.removeEventListener('error', handleError);
+      window.removeEventListener('unhandledrejection', handleRejection);
+    };
+  });
+</script>

--- a/src/routes/(public)/report/+page.svelte
+++ b/src/routes/(public)/report/+page.svelte
@@ -44,6 +44,15 @@
     extra: "",
   });
 
+  import { onMount } from "svelte";
+  onMount(() => {
+    const url = new URL(window.location.href);
+    const err = url.searchParams.get("error");
+    if (err) {
+      bug.extra = `Error message: ${err}`;
+    }
+  });
+
   // Feature suggestion state
   let feature: {
     title: string;

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -49,7 +49,12 @@
       class="flex flex-col sm:flex-row gap-4 justify-center mb-4 z-10 relative"
     >
       <a href="/" class="btn btn-lg btn-primary"> 🏠 Return Home </a>
-      <a class="btn btn-lg btn-error" href="/report"> 🐞 Report the Bug </a>
+      <a
+        class="btn btn-lg btn-error"
+        href={`/report?error=${encodeURIComponent(page.error?.message || '')}`}
+      >
+        🐞 Report the Bug
+      </a>
     </div>
 
     <!-- Bouncing Cube -->

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -9,6 +9,7 @@
   import { Ssgoi } from "@ssgoi/svelte";
   import { blur } from "@ssgoi/svelte/transitions";
   import { hero } from "@ssgoi/svelte/view-transitions";
+  import ClientErrorReporter from "$lib/components/misc/clientErrorReporter.svelte";
 
   const config = {
     defaultTransition: blur(),
@@ -71,6 +72,7 @@
 <Navbar session={data.session} />
 
 <Toaster />
+<ClientErrorReporter />
 
 <Ssgoi {config}>
   <section class="bg-base-100 relative">


### PR DESCRIPTION
## Summary
- add client error reporting component
- link to bug report page with error message from server errors
- prefill error message on bug report

## Testing
- `npm run lint` *(fails: 170 errors)*
- `npm test` *(fails to resolve imports)*

------
https://chatgpt.com/codex/tasks/task_e_688c2c174efc832cbe9df8d92eb5a7a7