### PR TITLE
Add share feature for cubes and profiles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@number-flow/svelte": "^0.3.9",
         "@oslojs/crypto": "^1.0.1",
         "@oslojs/encoding": "^1.1.0",
+        "@ssgoi/svelte": "^0.0.8",
         "@supabase/ssr": "^0.6.1",
         "@supabase/supabase-js": "^2.49.4",
         "@tailwindcss/typography": "^0.5.16",
@@ -2685,6 +2686,27 @@
       "license": "Apache-2.0",
       "bin": {
         "sqlite-wasm": "bin/index.js"
+      }
+    },
+    "node_modules/@ssgoi/core": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@ssgoi/core/-/core-0.0.3.tgz",
+      "integrity": "sha512-PW7VkvLUWF83fk5aDuYyyahpL0k/4uo3vzgxEXRgAK6ryAoSJMib8ZEnnfCK6M59VCsDyR79200kuW3PC76V4A==",
+      "license": "MIT",
+      "dependencies": {
+        "popmotion": "^11.0.5"
+      }
+    },
+    "node_modules/@ssgoi/svelte": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@ssgoi/svelte/-/svelte-0.0.8.tgz",
+      "integrity": "sha512-IDSpACBfqfsqH1Z+aNhgD6v2OfKwpYiJEcp4x5hVN1hvGCjo0yFmrsr6q0GCcGPAw10ysKcAOOv8LlAvMfihow==",
+      "license": "MIT",
+      "dependencies": {
+        "@ssgoi/core": "0.0.3"
+      },
+      "peerDependencies": {
+        "svelte": "^5.0.0"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -6128,6 +6150,21 @@
         "node": ">= 6"
       }
     },
+    "node_modules/framesync": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.1.2.tgz",
+      "integrity": "sha512-jBTqhX6KaQVDyus8muwZbBeGGP0XgujBRbQ7gM7BRdS3CadCZIHiawyzYLnafYcvZIh5j8WE7cxZKFn7dXhu9g==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.4.0"
+      }
+    },
+    "node_modules/framesync/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "license": "0BSD"
+    },
     "node_modules/fs-extra": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -6448,6 +6485,12 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/hey-listen": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
+      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==",
+      "license": "MIT"
     },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
@@ -8221,6 +8264,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/popmotion": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.5.tgz",
+      "integrity": "sha512-la8gPM1WYeFznb/JqF4GiTkRRPZsfaj2+kCxqQgr2MJylMmIKUwBfWW8Wa5fml/8gmtlD5yI01MP1QCZPWmppA==",
+      "license": "MIT",
+      "dependencies": {
+        "framesync": "6.1.2",
+        "hey-listen": "^1.0.8",
+        "style-value-types": "5.1.2",
+        "tslib": "2.4.0"
+      }
+    },
+    "node_modules/popmotion/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "license": "0BSD"
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -9385,6 +9446,22 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/style-value-types": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.1.2.tgz",
+      "integrity": "sha512-Vs9fNreYF9j6W2VvuDTP7kepALi7sk0xtk2Tu8Yxi9UoajJdEVpNpCov0HsLTqXvNGKX+Uv09pkozVITi1jf3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "hey-listen": "^1.0.8",
+        "tslib": "2.4.0"
+      }
+    },
+    "node_modules/style-value-types/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "license": "0BSD"
     },
     "node_modules/styled-jsx": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@number-flow/svelte": "^0.3.9",
     "@oslojs/crypto": "^1.0.1",
     "@oslojs/encoding": "^1.1.0",
+    "@ssgoi/svelte": "^0.0.8",
     "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.49.4",
     "@tailwindcss/typography": "^0.5.16",

--- a/src/lib/components/misc/shareButton.svelte
+++ b/src/lib/components/misc/shareButton.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  export let url: string = '';
+  export let text: string = 'Check this out!';
+  export let label: string = 'Share';
+  export let btnClass: string = 'btn btn-accent';
+
+  async function shareCurrent() {
+    if (!url) url = window.location.href;
+    if (navigator.share) {
+      try {
+        await navigator.share({ title: document.title, text, url });
+        return;
+      } catch (err) {
+        console.error('Share failed', err);
+      }
+    }
+
+    try {
+      await navigator.clipboard.writeText(url);
+      alert('Link copied to clipboard');
+    } catch (err) {
+      console.error('Copy failed', err);
+      prompt('Copy this link:', url);
+    }
+  }
+</script>
+
+<button class={btnClass} type="button" onclick={shareCurrent} aria-label={label}>
+  <i class="fa-solid fa-share"></i>
+  <span class="ml-2">{label}</span>
+</button>

--- a/src/routes/(private)/user/[id]/+layout.svelte
+++ b/src/routes/(private)/user/[id]/+layout.svelte
@@ -2,6 +2,8 @@
   import Badge from "$lib/components/user/badge.svelte";
   import Report from "$lib/components/report/report.svelte";
   import { formatDate } from "$lib/components/helper_functions/formatDate.svelte.js";
+  import ShareButton from "$lib/components/misc/shareButton.svelte";
+  import { page } from "$app/state";
 
   const { data, children } = $props();
   const { user, profile } = data;
@@ -121,6 +123,7 @@
                 <span>Report</span>
               </button>
             {/if}
+            <ShareButton url={page.url.href} btnClass="btn hidden md:flex" />
             <button
               class="btn block md:hidden"
               popovertarget="popover-1"
@@ -154,6 +157,9 @@
                   <span>Report</span>
                 </button>
               {/if}
+              <button class="flex justify-end items-center gap-2 p-2">
+                <ShareButton url={page.url.href} btnClass="btn w-full" />
+              </button>
             </ul>
           </div>
           <p class="mt-2">

--- a/src/routes/(public)/explore/cubes/[slug]/+page.svelte
+++ b/src/routes/(public)/explore/cubes/[slug]/+page.svelte
@@ -12,6 +12,7 @@
   import { page } from "$app/state";
   import { SsgoiTransition } from "@ssgoi/svelte";
   import AddToCollectionButton from "$lib/components/misc/addToCollectionButton.svelte";
+  import ShareButton from "$lib/components/misc/shareButton.svelte";
 
   let { data } = $props();
   let {
@@ -275,20 +276,23 @@
             have this cube
           </p>
 
-          {#if cube.status === "Approved"}
-            <AddToCollectionButton
-              onClick={() => (openAddCard = !openAddCard)}
-              alreadyAdded={userCubeDetail !== undefined ? true : false}
-            />
-          {:else}
-            <button
-              class="btn btn-error flex-1 mb-4 cursor-not-allowed"
-              type="button"
-              aria-label="Add to Collection"
-            >
-              Only approved cubes can be added to your collection.
-            </button>
-          {/if}
+          <div class="flex flex-wrap gap-2 mb-4">
+            {#if cube.status === "Approved"}
+              <AddToCollectionButton
+                onClick={() => (openAddCard = !openAddCard)}
+                alreadyAdded={userCubeDetail !== undefined ? true : false}
+              />
+            {:else}
+              <button
+                class="btn btn-error flex-1 cursor-not-allowed"
+                type="button"
+                aria-label="Add to Collection"
+              >
+                Only approved cubes can be added to your collection.
+              </button>
+            {/if}
+            <ShareButton url={page.url.href} />
+          </div>
 
           <!-- Highlighted Rating -->
           <div class="flex flex-col items-start mb-5 sm:mt-0">


### PR DESCRIPTION
## Summary
- add new `ShareButton` component to copy or share links
- use `ShareButton` on cube detail pages
- enable sharing from user profile pages
- install `@ssgoi/svelte` dependency so tests run

## Testing
- `npm test` *(fails: getSsgoiContext must be called within Ssgoi component)*

------
https://chatgpt.com/codex/tasks/task_e_688c2ee49a30832c8a32cefb0d33cbd0