### PR TITLE
feat: improve mobile navbar button

### DIFF
--- a/src/lib/components/layout/navbar.svelte
+++ b/src/lib/components/layout/navbar.svelte
@@ -171,11 +171,12 @@
 
     <!-- Mobile Menu Button -->
     <button
+      class="btn btn-square btn-ghost md:hidden swap swap-rotate text-2xl {isOpen ? 'swap-active' : ''}"
+      aria-label={isOpen ? "Close menu" : "Open menu"}
       onclick={() => (isOpen = !isOpen)}
-      class="focus:outline-none md:hidden cursor-pointer"
-      aria-label="Open menu"
     >
-      <i class="fa-solid fa-bars"></i>
+      <i class="fa-solid fa-bars swap-off"></i>
+      <i class="fa-solid fa-xmark swap-on"></i>
     </button>
   </div>
 


### PR DESCRIPTION
## Summary
- add animated toggle with open/close states to mobile menu button
- enlarge mobile menu trigger for better touch targets

## Testing
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ed171bb80832ca6f4861f6713927b