### PR TITLE
fix: ensure profile layout updates on navigation

### DIFF
--- a/src/routes/(private)/user/[username]/+layout.svelte
+++ b/src/routes/(private)/user/[username]/+layout.svelte
@@ -9,7 +9,9 @@
   import FollowButton from "$lib/components/misc/followButton.svelte";
 
   const { data, children } = $props();
-  const { user, profile, following } = data;
+  let user = $derived(data.user);
+  let profile = $derived(data.profile);
+  let following = $derived(data.following);
 
   interface socialObject {
     label?: string;


### PR DESCRIPTION
## Summary
- make profile layout data reactive so navigating between users shows correct profile

## Testing
- `npm test` (fails: getSsgoiContext must be called within Ssgoi component)
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ed687d3c8832c8a34c3b69bdf9e98