### PR TITLE
Fix Discord link in the demo page

### DIFF
--- a/src/lib/components/navbar.svelte
+++ b/src/lib/components/navbar.svelte
@@ -14,7 +14,7 @@
 
 		<!-- Desktop Nav -->
 		<nav class="hidden items-center gap-8 md:flex">
-			<a href="https://discord.gg/YvhEjgQ7Fq" class="rounded-xl bg-blue-600 px-4 py-2 text-sm transition hover:bg-blue-700">
+			<a href="https://discord.gg/76ExrEAE7s" class="rounded-xl bg-blue-600 px-4 py-2 text-sm transition hover:bg-blue-700">
 				Join the Discord
 			</a>
 		</nav>
@@ -35,7 +35,7 @@
 			<ul class="flex flex-col gap-3">
 				<li>
 					<a
-						href="https://discord.gg/YvhEjgQ7Fq"
+						href="https://discord.gg/76ExrEAE7s"
 						class="mt-2 block rounded-xl bg-blue-600 py-2 text-center text-white transition hover:bg-blue-700"
 					>
 						Join the Discord


### PR DESCRIPTION
The link in the navigation bar of the demo page was invalid, so I replaced it with another one that works.