### PR TITLE
Fix the cube detail page 500 error code when not logged in

### DIFF
--- a/src/routes/(public)/explore/cubes/[slug]/+page.server.ts
+++ b/src/routes/(public)/explore/cubes/[slug]/+page.server.ts
@@ -13,18 +13,21 @@ export const load = async ({ locals }) => {
     cubesAvailability = value;
   });
 
-  const { data, error: pErr } = await locals.supabase
-    .from("profiles")
-    .select("*")
-    .eq("user_id", locals.user?.id)
-    .single();
+  let profile: Profiles = {} as Profiles;
 
-  if (pErr) {
-    throw new Error(`500, Failed to fetch profiles: ${pErr.message}`);
-    return;
+  if (locals.user?.id) {
+    const { data, error: pErr } = await locals.supabase
+      .from("profiles")
+      .select("*")
+      .eq("user_id", locals.user?.id)
+      .single();
+
+    if (pErr) {
+      throw new Error(`500, Failed to fetch profiles: ${pErr.message}`);
+    }
+
+    profile = data;
   }
-
-  const profile: Profiles = data;
 
   return { databaseAvailability, cubesAvailability, profile };
 };


### PR DESCRIPTION
This pull request fixes the 500 error code that occurs when you go to the cube detail page while not being logged in.