### PR TITLE
Fix the bug where the add to collection modal does not display correctly

### DIFF
--- a/src/lib/components/cube/addCube.svelte
+++ b/src/lib/components/cube/addCube.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { getContext } from "svelte";
   import { blur } from "svelte/transition";
+  import Portal from "../misc/portal.svelte";
 
   let {
     onCancel,
@@ -68,144 +69,146 @@
   }
 </script>
 
-<div
-  class="fixed inset-0 bg-black/60 backdrop-blur-md flex items-center justify-center z-50"
-  transition:blur
->
-  <form
-    class="card max-w-lg transform absolute z-50 backdrop-blur-3xl bg-base-100/80 backdrop-opacity-100 flex items-center mx-1"
-    onsubmit={addCubeToCollec}
+<Portal>
+  <div
+    class="fixed inset-0 bg-black/60 backdrop-blur-md flex items-center justify-center z-50"
+    transition:blur
   >
-    <div class="card-body">
-      <h2 class="card-title">
-        You are adding the {cube.series}
-        {cube.model}
-        {cube.version_type !== "Base" ? cube.version_name : ""} to your collection
-      </h2>
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <!-- Quantity -->
-        <label class="flex flex-col">
-          <span class="label-text"
-            >Quantity {status === "Wishlist"
-              ? "(Qty can't be changed for wishlisted cubes.)"
-              : ""}</span
+    <form
+      class="card max-w-lg transform absolute z-50 backdrop-blur-3xl bg-base-100/80 backdrop-opacity-100 flex items-center mx-1"
+      onsubmit={addCubeToCollec}
+    >
+      <div class="card-body">
+        <h2 class="card-title">
+          You are adding the {cube.series}
+          {cube.model}
+          {cube.version_type !== "Base" ? cube.version_name : ""} to your collection
+        </h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <!-- Quantity -->
+          <label class="flex flex-col">
+            <span class="label-text"
+              >Quantity {status === "Wishlist"
+                ? "(Qty can't be changed for wishlisted cubes.)"
+                : ""}</span
+            >
+            <input
+              name="quantity"
+              type="number"
+              min="1"
+              max="999"
+              bind:value={quantity}
+              class="input w-full"
+              readonly={status === "Wishlist"}
+              required
+            />
+          </label>
+          <!-- Main cube toggle -->
+          <label class="flex items-center space-x-2 mt-6">
+            <input
+              type="checkbox"
+              name="main"
+              bind:checked={main}
+              class="checkbox bg-base-100"
+            />
+            <span>Main Cube</span>
+          </label>
+          <!-- Condition -->
+          <label class="flex flex-col">
+            <span class="label-text">Condition</span>
+            <select
+              name="condition"
+              bind:value={condition}
+              class="select w-full"
+              required
+            >
+              <option value="New in box">New in box</option>
+              <option value="New">New</option>
+              <option value="Good">Good</option>
+              <option value="Fair">Fair</option>
+              <option value="Worn">Worn</option>
+              <option value="Poor">Poor</option>
+              <option value="Broken">Broken</option>
+            </select>
+          </label>
+          <!-- Status -->
+          <label class="flex flex-col">
+            <span class="label-text">Status</span>
+            <select
+              name="status"
+              bind:value={status}
+              class="select w-full"
+              required
+            >
+              <option value="Owned">Owned</option>
+              <option value="Wishlist">Wishlist</option>
+              <option value="Loaned">Loaned</option>
+              <option value="Borrowed">Borrowed</option>
+              <option value="Lost">Lost</option>
+            </select>
+          </label>
+        </div>
+
+        <!-- Full-width fields -->
+        <div class="mt-4 space-y-4">
+          <label class="flex flex-col">
+            <span class="label-text">Notes</span>
+            <textarea
+              name="notes"
+              placeholder="Any special notes..."
+              bind:value={notes}
+              class="textarea textarea-bordered rounded-2xl w-full max-h-50"
+            ></textarea>
+          </label>
+          <label class="flex flex-col">
+            <span class="label-text">Acquired The</span>
+            <input
+              name="acquiredAt"
+              type="date"
+              bind:value={acquired_at}
+              class="input input-bordered w-full"
+            />
+          </label>
+        </div>
+      </div>
+
+      <div class="flex justify-between w-full">
+        <div class="card-actions p-4">
+          <button
+            class="btn btn-secondary"
+            type="button"
+            onclick={onCancel}
+            disabled={isSubmitting}>Cancel</button
           >
-          <input
-            name="quantity"
-            type="number"
-            min="1"
-            max="999"
-            bind:value={quantity}
-            class="input w-full"
-            readonly={status === "Wishlist"}
-            required
-          />
-        </label>
-        <!-- Main cube toggle -->
-        <label class="flex items-center space-x-2 mt-6">
-          <input
-            type="checkbox"
-            name="main"
-            bind:checked={main}
-            class="checkbox bg-base-100"
-          />
-          <span>Main Cube</span>
-        </label>
-        <!-- Condition -->
-        <label class="flex flex-col">
-          <span class="label-text">Condition</span>
-          <select
-            name="condition"
-            bind:value={condition}
-            class="select w-full"
-            required
+        </div>
+
+        <div class="card-actions p-4">
+          <button
+            class="btn btn-primary"
+            type="submit"
+            disabled={isSubmitting || !isConnected}
           >
-            <option value="New in box">New in box</option>
-            <option value="New">New</option>
-            <option value="Good">Good</option>
-            <option value="Fair">Fair</option>
-            <option value="Worn">Worn</option>
-            <option value="Poor">Poor</option>
-            <option value="Broken">Broken</option>
-          </select>
-        </label>
-        <!-- Status -->
-        <label class="flex flex-col">
-          <span class="label-text">Status</span>
-          <select
-            name="status"
-            bind:value={status}
-            class="select w-full"
-            required
-          >
-            <option value="Owned">Owned</option>
-            <option value="Wishlist">Wishlist</option>
-            <option value="Loaned">Loaned</option>
-            <option value="Borrowed">Borrowed</option>
-            <option value="Lost">Lost</option>
-          </select>
-        </label>
+            {#if isSubmitting}
+              <span class="loading loading-spinner"></span>
+              Adding...
+            {:else if showSuccess}
+              <i class="fa-solid fa-check"></i>
+              Added!
+            {:else}
+              Add Cube
+            {/if}
+          </button>
+        </div>
       </div>
 
-      <!-- Full-width fields -->
-      <div class="mt-4 space-y-4">
-        <label class="flex flex-col">
-          <span class="label-text">Notes</span>
-          <textarea
-            name="notes"
-            placeholder="Any special notes..."
-            bind:value={notes}
-            class="textarea textarea-bordered rounded-2xl w-full max-h-50"
-          ></textarea>
-        </label>
-        <label class="flex flex-col">
-          <span class="label-text">Acquired The</span>
-          <input
-            name="acquiredAt"
-            type="date"
-            bind:value={acquired_at}
-            class="input input-bordered w-full"
-          />
-        </label>
-      </div>
-    </div>
-
-    <div class="flex justify-between w-full">
-      <div class="card-actions p-4">
-        <button
-          class="btn btn-secondary"
-          type="button"
-          onclick={onCancel}
-          disabled={isSubmitting}>Cancel</button
-        >
-      </div>
-
-      <div class="card-actions p-4">
-        <button
-          class="btn btn-primary"
-          type="submit"
-          disabled={isSubmitting || !isConnected}
-        >
-          {#if isSubmitting}
-            <span class="loading loading-spinner"></span>
-            Adding...
-          {:else if showSuccess}
-            <i class="fa-solid fa-check"></i>
-            Added!
-          {:else}
-            Add Cube
-          {/if}
-        </button>
-      </div>
-    </div>
-
-    {#if formMessage}
-      <div class="text-error p-2 flex justify-center">{formMessage}</div>
-    {/if}
-    {#if !isConnected}
-      <p class="text-error p-2 flex justify-center">
-        You must be logged in to perform this action
-      </p>
-    {/if}
-  </form>
-</div>
+      {#if formMessage}
+        <div class="text-error p-2 flex justify-center">{formMessage}</div>
+      {/if}
+      {#if !isConnected}
+        <p class="text-error p-2 flex justify-center">
+          You must be logged in to perform this action
+        </p>
+      {/if}
+    </form>
+  </div>
+</Portal>

--- a/src/lib/components/misc/portal.svelte
+++ b/src/lib/components/misc/portal.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { onMount, onDestroy } from "svelte";
+
+  const { children } = $props();
+
+  let portal: HTMLDivElement;
+
+  onMount(() => {
+    document.body.appendChild(portal);
+  });
+
+  onDestroy(() => {
+    portal.remove();
+  });
+</script>
+
+<div bind:this={portal}>
+  {@render children()}
+</div>

--- a/src/lib/components/rating/rateCube.svelte
+++ b/src/lib/components/rating/rateCube.svelte
@@ -2,6 +2,7 @@
   import { blur } from "svelte/transition";
   import StarRating from "./starRating.svelte";
   import { getContext } from "svelte";
+  import Portal from "../misc/portal.svelte";
 
   let { onCancel, cube, rating = 0, comment = "" } = $props();
 
@@ -47,72 +48,74 @@
   }
 </script>
 
-<div
-  class="fixed inset-0 bg-black/60 backdrop-blur-md flex items-center justify-center z-50"
-  transition:blur
->
+<Portal>
   <div
-    class="card max-w-lg transform absolute z-50 backdrop-blur-3xl bg-base-100/80 backdrop-opacity-100 flex items-center mx-1"
+    class="fixed inset-0 bg-black/60 backdrop-blur-md flex items-center justify-center z-50"
+    transition:blur
   >
-    <form onsubmit={rateCube}>
-      <div class="card-body min-w-full">
-        <h2 class="card-title">
-          You are rating the {cube.series}
-          {cube.model}
-          {cube.version_type !== "Base" ? cube.version_name : null}
-        </h2>
+    <div
+      class="card max-w-lg transform absolute z-50 backdrop-blur-3xl bg-base-100/80 backdrop-opacity-100 flex items-center mx-1"
+    >
+      <form onsubmit={rateCube}>
+        <div class="card-body min-w-full">
+          <h2 class="card-title">
+            You are rating the {cube.series}
+            {cube.model}
+            {cube.version_type !== "Base" ? cube.version_name : null}
+          </h2>
 
-        <StarRating readOnly={false} bind:rating />
+          <StarRating readOnly={false} bind:rating />
 
-        <!-- Full-width fields -->
-        <div class="mt-4 space-y-4">
-          <label class="flex flex-col">
-            <span class="label-text">Comment</span>
-            <textarea
-              bind:value={comment}
-              class="textarea textarea-bordered rounded-2xl w-full max-h-50 resize max-w-md"
-            ></textarea>
-          </label>
-        </div>
-      </div>
-
-      <div class="flex justify-between">
-        <div class="card-actions p-4">
-          <button
-            class="btn btn-secondary"
-            type="button"
-            onclick={onCancel}
-            disabled={isSubmitting}>Cancel</button
-          >
+          <!-- Full-width fields -->
+          <div class="mt-4 space-y-4">
+            <label class="flex flex-col">
+              <span class="label-text">Comment</span>
+              <textarea
+                bind:value={comment}
+                class="textarea textarea-bordered rounded-2xl w-full max-h-50 resize max-w-md"
+              ></textarea>
+            </label>
+          </div>
         </div>
 
-        <div class="card-actions p-4">
-          <button
-            class="btn btn-primary"
-            type="submit"
-            disabled={isSubmitting || !isConnected}
-          >
-            {#if isSubmitting}
-              <span class="loading loading-spinner"></span>
-              Rating...
-            {:else if showSuccess}
-              <i class="fa-solid fa-check"></i>
-              Rated!
-            {:else}
-              Rate Cube
-            {/if}
-          </button>
-        </div>
-      </div>
+        <div class="flex justify-between">
+          <div class="card-actions p-4">
+            <button
+              class="btn btn-secondary"
+              type="button"
+              onclick={onCancel}
+              disabled={isSubmitting}>Cancel</button
+            >
+          </div>
 
-      {#if formMessage}
-        <div class="text-error p-2 flex justify-center">{formMessage}</div>
-      {/if}
-      {#if !isConnected}
-        <p class="text-error p-2 flex justify-center">
-          You must be logged in to perform this action
-        </p>
-      {/if}
-    </form>
+          <div class="card-actions p-4">
+            <button
+              class="btn btn-primary"
+              type="submit"
+              disabled={isSubmitting || !isConnected}
+            >
+              {#if isSubmitting}
+                <span class="loading loading-spinner"></span>
+                Rating...
+              {:else if showSuccess}
+                <i class="fa-solid fa-check"></i>
+                Rated!
+              {:else}
+                Rate Cube
+              {/if}
+            </button>
+          </div>
+        </div>
+
+        {#if formMessage}
+          <div class="text-error p-2 flex justify-center">{formMessage}</div>
+        {/if}
+        {#if !isConnected}
+          <p class="text-error p-2 flex justify-center">
+            You must be logged in to perform this action
+          </p>
+        {/if}
+      </form>
+    </div>
   </div>
-</div>
+</Portal>


### PR DESCRIPTION
This pull request fixes the bug where the add to collection and rate cube modal didn't display correctly on the cube explore page.

This bug was caused by the page transitions by Ssgoi that changed the parent container style in a way that made the modal appear below all the other cube cards and made the blur not apply correctly.

This pull request fixes it by making the modal appear after the Ssgoi transition container for it not to be impacted by it's styling.