### PR TITLE
feat: add price and ratings pages

### DIFF
--- a/src/routes/(public)/explore/cubes/[slug]/+page.svelte
+++ b/src/routes/(public)/explore/cubes/[slug]/+page.svelte
@@ -4,9 +4,7 @@
   import CubeVersionType from "$lib/components/cube/cubeVersionType.svelte";
   import type { Cube } from "$lib/components/dbTableTypes.js";
   import { formatDate } from "$lib/components/helper_functions/formatDate.svelte.js";
-  import type { CubeVendorLinks } from "$lib/components/dbTableTypes.js";
   import type { Profiles } from "$lib/components/dbTableTypes.js";
-  import UserRatings from "$lib/components/rating/userRatings.svelte";
   import Report from "$lib/components/report/report.svelte";
   import { page } from "$app/state";
   import { SsgoiTransition } from "@ssgoi/svelte";
@@ -17,7 +15,6 @@
   let {
     cube = {} as Cube,
     profile = {} as Profiles,
-    user_cube_ratings,
     cubeTrims,
     relatedCube,
     sameSeries,
@@ -39,7 +36,6 @@
   const isDiscontinued = $derived.by(() => cube.discontinued);
   const isModded = $derived.by(() => feats.has("modded"));
 
-  let vendor_links: CubeVendorLinks[] | undefined = $derived(data.vendor_links);
   let cubeUserCount: number | undefined = $derived(
     data.user_cubes?.length ?? 0
   );
@@ -192,6 +188,24 @@
         <ShareButton url={page.url.href} />
       </div>
 
+      <nav class="mb-6 flex flex-wrap gap-2">
+        <a
+          href="/explore/cubes/{cube.slug}"
+          class="btn btn-sm btn-primary"
+          >Details</a
+        >
+        <a
+          href="/explore/cubes/{cube.slug}/price"
+          class="btn btn-sm"
+          >Price Tracking</a
+        >
+        <a
+          href="/explore/cubes/{cube.slug}/ratings"
+          class="btn btn-sm"
+          >Ratings</a
+        >
+      </nav>
+
       <!-- Highlighted Rating -->
       <div class="flex flex-col items-start mb-5 sm:mt-0">
         <StarRating readOnly={true} rating={cube.rating ?? 0} />
@@ -275,34 +289,6 @@
           {/each}
         </div>
       </div>
-      {#if vendor_links && vendor_links.length > 0}
-        <div class="my-8">
-          <h2 class="text-lg font-semibold mb-3 flex items-center gap-2">
-            <i class="fa-solid fa-cart-shopping"></i>
-            Available at:
-          </h2>
-          <div class="flex flex-wrap gap-3">
-            {#each vendor_links as shop}
-              <a
-                href={shop.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                class="btn btn-outline {shop.available
-                  ? 'btn-primary'
-                  : 'btn-error'}"
-              >
-                {#if shop.available}
-                  <i class="fa-solid fa-check"></i>
-                {:else}
-                  <i class="fa-solid fa-xmark"></i>
-                {/if}
-                {shop.vendor_name} ・ ≃ {shop.price} $
-              </a>
-            {/each}
-          </div>
-        </div>
-      {/if}
-
       <div class="my-8">
         <div class="bg-base-200 rounded-xl p-4 border border-base-300">
           <h2 class="text-lg font-semibold mb-3 flex items-center gap-2">
@@ -443,7 +429,6 @@
           </div>
         </div>
       {/if}
-      <UserRatings user_cube_ratings={user_cube_ratings ?? []} {cube} />
       <div class="mt-4">
         <button onclick={toggleOpenReport} class="btn btn-error">
           🚩 Report incorrect/missing data

--- a/src/routes/(public)/explore/cubes/[slug]/+page.ts
+++ b/src/routes/(public)/explore/cubes/[slug]/+page.ts
@@ -173,31 +173,14 @@ export const load = (async ({ setHeaders, params, url, parent }) => {
 
   const [
     { data: features, error: featErr },
-    { data: user_cube_ratings, error: urErr },
-    { data: vendor_links, error: cvlErr },
     { data: user_cubes, error: ucErr },
   ] = await Promise.all([
     supabase.from("cubes_model_features").select("*").eq("cube", cube.slug),
-    supabase
-      .from("user_cube_ratings")
-      .select("*, profile:user_id(username, display_name)")
-      .eq("cube_slug", cube.slug),
-    supabase.from("cube_vendor_links").select("*").eq("cube_slug", cube.slug),
     supabase.from("user_cubes").select("*").eq("cube", cube.slug),
   ]);
 
   if (featErr) {
     throw new Error("A 500 status code error occured:" + featErr.message);
-  }
-
-  if (urErr) {
-    throw new Error(`Failed to fetch user ratings: ${urErr.message}`);
-  }
-
-  if (cvlErr) {
-    throw new Error(
-      `500, Failed to fetch vendor links for cube "${cube.slug}": ${cvlErr.message}`
-    );
   }
 
   if (ucErr) {
@@ -213,8 +196,6 @@ export const load = (async ({ setHeaders, params, url, parent }) => {
     profile,
     cube,
     features,
-    vendor_links,
-    user_cube_ratings,
     user_cubes,
     sameSeries: sameSeriesRes.data ?? [],
     relatedCube: relatedRes.data ?? null,
@@ -235,10 +216,10 @@ export const load = (async ({ setHeaders, params, url, parent }) => {
           {
             cube: cube,
             features,
+            vendor_links: [],
+            user_cube_ratings: [],
             relatedCube: (relatedRes.data as Cube) ?? null,
             sameSeries: (sameSeriesRes.data as Cube[]) ?? [],
-            user_cube_ratings,
-            vendor_links,
           },
           origin,
           href

--- a/src/routes/(public)/explore/cubes/[slug]/price/+page.svelte
+++ b/src/routes/(public)/explore/cubes/[slug]/price/+page.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+	import type { Cube, CubeVendorLinks } from "$lib/components/dbTableTypes";
+
+	let { data } = $props();
+	let {
+		cube = {} as Cube,
+		vendor_links = [] as CubeVendorLinks[],
+	} = $derived(data);
+
+	const pageTitle = $derived(
+		`${cube.series} ${cube.model}${
+			cube.version_name ? ` ${cube.version_name}` : ""
+		} - Price Tracking`
+	);
+</script>
+
+<svelte:head>
+	<title>{pageTitle}</title>
+</svelte:head>
+
+<section class="min-h-screen px-6 py-16">
+	<div class="max-w-4xl mx-auto">
+		<h1 class="text-3xl font-bold mb-4">
+			{cube.series} {cube.model}
+			{#if cube.version_type !== "Base"}
+				<span class="text-secondary"> {cube.version_name}</span>
+			{/if}
+		</h1>
+
+		<nav class="mb-6 flex flex-wrap gap-2">
+			<a href="/explore/cubes/{cube.slug}" class="btn btn-sm">Details</a>
+			<a
+				href="/explore/cubes/{cube.slug}/price"
+				class="btn btn-sm btn-primary"
+				>Price Tracking</a
+			>
+			<a href="/explore/cubes/{cube.slug}/ratings" class="btn btn-sm"
+				>Ratings</a
+			>
+		</nav>
+
+		{#if vendor_links.length > 0}
+			<div class="my-8">
+				<h2 class="text-lg font-semibold mb-3 flex items-center gap-2">
+					<i class="fa-solid fa-cart-shopping"></i>
+					Available at:
+				</h2>
+				<div class="flex flex-wrap gap-3">
+					{#each vendor_links as shop}
+						<a
+							href={shop.url}
+							target="_blank"
+							rel="noopener noreferrer"
+							class="btn btn-outline {shop.available ? 'btn-primary' : 'btn-error'}"
+						>
+							{#if shop.available}
+								<i class="fa-solid fa-check"></i>
+							{:else}
+								<i class="fa-solid fa-xmark"></i>
+							{/if}
+							{shop.vendor_name} ・ ≃ {shop.price} $
+						</a>
+					{/each}
+				</div>
+			</div>
+		{:else}
+			<p>No vendor information available.</p>
+		{/if}
+	</div>
+</section>
+

--- a/src/routes/(public)/explore/cubes/[slug]/price/+page.ts
+++ b/src/routes/(public)/explore/cubes/[slug]/price/+page.ts
@@ -1,0 +1,41 @@
+import type { PageLoad } from "./$types";
+import type { Cube } from "$lib/components/dbTableTypes";
+import { error } from "@sveltejs/kit";
+
+export const load = (async ({ parent, params }) => {
+	const { supabase } = await parent();
+	const { slug } = params;
+
+	const cubePromise = supabase
+		.from("cube_models")
+		.select(
+			"*, verified_by_id(display_name, username), submitted_by_id(display_name, username)"
+		)
+		.eq("slug", slug)
+		.single();
+
+	const vendorLinksPromise = supabase
+		.from("cube_vendor_links")
+		.select("*")
+		.eq("cube_slug", slug);
+
+	const [cubeRes, vendorRes] = await Promise.all([
+		cubePromise,
+		vendorLinksPromise,
+	]);
+
+	const cube = cubeRes.data as Cube | null;
+
+	if (!cube) throw error(404, "Cube not found");
+	if (vendorRes.error) {
+		throw new Error(
+			`Failed to fetch vendor links for cube "${slug}": ${vendorRes.error.message}`
+		);
+	}
+
+	return {
+		cube,
+		vendor_links: vendorRes.data ?? [],
+	};
+}) satisfies PageLoad;
+

--- a/src/routes/(public)/explore/cubes/[slug]/ratings/+page.svelte
+++ b/src/routes/(public)/explore/cubes/[slug]/ratings/+page.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+	import UserRatings from "$lib/components/rating/userRatings.svelte";
+	import type { Cube } from "$lib/components/dbTableTypes";
+
+	let { data } = $props();
+	let {
+		cube = {} as Cube,
+		user_cube_ratings = [] as any[],
+	} = $derived(data);
+
+	const pageTitle = $derived(
+		`${cube.series} ${cube.model}${
+			cube.version_name ? ` ${cube.version_name}` : ""
+		} - Ratings`
+	);
+</script>
+
+<svelte:head>
+	<title>{pageTitle}</title>
+</svelte:head>
+
+<section class="min-h-screen px-6 py-16">
+	<div class="max-w-4xl mx-auto">
+		<h1 class="text-3xl font-bold mb-4">
+			{cube.series} {cube.model}
+			{#if cube.version_type !== "Base"}
+				<span class="text-secondary"> {cube.version_name}</span>
+			{/if}
+		</h1>
+
+		<nav class="mb-6 flex flex-wrap gap-2">
+			<a href="/explore/cubes/{cube.slug}" class="btn btn-sm">Details</a>
+			<a href="/explore/cubes/{cube.slug}/price" class="btn btn-sm"
+				>Price Tracking</a
+			>
+			<a
+				href="/explore/cubes/{cube.slug}/ratings"
+				class="btn btn-sm btn-primary"
+				>Ratings</a
+			>
+		</nav>
+
+		<UserRatings {user_cube_ratings} {cube} />
+	</div>
+</section>
+

--- a/src/routes/(public)/explore/cubes/[slug]/ratings/+page.ts
+++ b/src/routes/(public)/explore/cubes/[slug]/ratings/+page.ts
@@ -1,0 +1,39 @@
+import type { PageLoad } from "./$types";
+import type { Cube } from "$lib/components/dbTableTypes";
+import { error } from "@sveltejs/kit";
+
+export const load = (async ({ parent, params }) => {
+	const { supabase } = await parent();
+	const { slug } = params;
+
+	const cubePromise = supabase
+		.from("cube_models")
+		.select("*")
+		.eq("slug", slug)
+		.single();
+
+	const ratingsPromise = supabase
+		.from("user_cube_ratings")
+		.select("*, profile:user_id(username, display_name)")
+		.eq("cube_slug", slug);
+
+	const [cubeRes, ratingsRes] = await Promise.all([
+		cubePromise,
+		ratingsPromise,
+	]);
+
+	const cube = cubeRes.data as Cube | null;
+
+	if (!cube) throw error(404, "Cube not found");
+	if (ratingsRes.error) {
+		throw new Error(
+			`Failed to fetch user ratings for cube "${slug}": ${ratingsRes.error.message}`
+		);
+	}
+
+	return {
+		cube,
+		user_cube_ratings: ratingsRes.data ?? [],
+	};
+}) satisfies PageLoad;
+


### PR DESCRIPTION
## Summary
- separate cube details from price and rating pages
- add dedicated price tracking and ratings routes

## Testing
- `npm run build`
- `npm run check` *(fails: Module 'drizzle-orm/pg-core' or its types not found, etc.)*
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fd1d7e40832c9a43b555abf6215d