### PR TITLE
Improve userbar data fetch and preview handling

### DIFF
--- a/src/lib/queries/detailedProfiles.ts
+++ b/src/lib/queries/detailedProfiles.ts
@@ -1,0 +1,70 @@
+import type PostgrestFilterBuilder from "@supabase/postgrest-js";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { UsersRoles } from "$lib/components/dbTableTypes";
+
+/**
+ * Column selection shared by every `v_detailed_profiles` query.
+ */
+export const DETAILED_PROFILE_COLUMNS = [
+	"id",
+	"created_at",
+	"user_id",
+	"username",
+	"private",
+	"profile_picture",
+	"bio",
+	"socials",
+	"banner",
+	"verified",
+	"certified",
+	"role",
+	"display_name",
+	"onboarded",
+	"user_cubes_count",
+	"user_achievements_count",
+	"user_following_count",
+	"user_follower_count",
+	"user_cube_ratings_count",
+	"user_avg_rating_count",
+].join(", ");
+
+/**
+ * Shape returned by the `v_detailed_profiles` view.
+ */
+export interface DetailedProfile {
+	id: number;
+	created_at: string;
+	user_id: string;
+	username: string;
+	private: boolean;
+	profile_picture: string | null;
+	bio: string | null;
+	socials: Record<string, unknown> | null;
+	banner: string | null;
+	verified: boolean;
+	certified: boolean;
+	role: UsersRoles;
+	display_name: string;
+	onboarded: boolean | null;
+	user_cubes_count: number;
+	user_achievements_count: number;
+	user_following_count: number;
+	user_follower_count: number;
+	user_cube_ratings_count: number;
+	user_avg_rating_count: number;
+}
+
+/**
+ * Builds a reusable `v_detailed_profiles` query with a consistent column list.
+ *
+ * @param client - Supabase client used to build the query.
+ * @returns Supabase query builder scoped to the view.
+ */
+export const queryDetailedProfiles = (client: SupabaseClient<any>) =>
+	client
+		.from("v_detailed_profiles")
+		.select(DETAILED_PROFILE_COLUMNS) as PostgrestFilterBuilder<
+			any,
+			DetailedProfile,
+			DetailedProfile[]
+		>;

--- a/src/routes/(public)/explore/users/+page.svelte
+++ b/src/routes/(public)/explore/users/+page.svelte
@@ -7,9 +7,10 @@
   import Pagination from "$lib/components/misc/pagination.svelte";
   import ItemsPerPageSelector from "$lib/components/misc/itemsPerPageSelector.svelte";
   import SortSelector from "$lib/components/misc/sortSelector.svelte";
+  import type { DetailedProfile } from "$lib/queries/detailedProfiles";
 
-  const { data } = $props();
-  const { profiles } = data;
+  const { data } = $props<{ data: { profiles: DetailedProfile[] } }>();
+  const profiles: DetailedProfile[] = data.profiles;
 
   let searchTerm: string = $state(""); // Text input for search bar
 

--- a/src/routes/(public)/explore/users/+page.ts
+++ b/src/routes/(public)/explore/users/+page.ts
@@ -1,14 +1,15 @@
 import type { PageLoad } from "./$types";
 import { supabase } from "$lib/supabaseClient";
+import { queryDetailedProfiles } from "$lib/queries/detailedProfiles";
 import { error } from "@sveltejs/kit";
 
 export const load = (async ({ setHeaders }) => {
-  const { data: profiles, error: err } = await supabase
-    .from("v_detailed_profiles")
-    .select("*")
+  const { data, error: err } = await queryDetailedProfiles(supabase)
     .order("id", { ascending: true });
 
   if (err) throw error(500, err.message);
+
+  const profiles = data ?? [];
 
   setHeaders({
     "Cache-Control": "public, s-maxage=600, stale-while-revalidate=86400",


### PR DESCRIPTION
## Summary
- add a typed helper for the v_detailed_profiles view and reuse it in the explore users loader
- refactor the userbar OG endpoint to use the shared query helper and cache font assets in module scope
- enhance the userbar preview with preload, loading overlay, refresh controls, and cache-busting support

## Testing
- npm run check *(fails: existing missing env vars and typing issues in unrelated routes)*

------
https://chatgpt.com/codex/tasks/task_e_68c85004c4f4832cb199fba356969f8a