### PR TITLE
Only show onboarded users in the explore user page

### DIFF
--- a/src/routes/(public)/explore/users/+page.svelte
+++ b/src/routes/(public)/explore/users/+page.svelte
@@ -9,7 +9,7 @@
   import SortSelector from "$lib/components/misc/sortSelector.svelte";
   import type { DetailedProfile } from "$lib/queries/detailedProfiles";
 
-  const { data } = $props<{ data: { profiles: DetailedProfile[] } }>();
+  const { data } = $props();
   const profiles: DetailedProfile[] = data.profiles;
 
   let searchTerm: string = $state(""); // Text input for search bar

--- a/src/routes/(public)/explore/users/+page.ts
+++ b/src/routes/(public)/explore/users/+page.ts
@@ -5,6 +5,7 @@ import { error } from "@sveltejs/kit";
 
 export const load = (async ({ setHeaders }) => {
   const { data, error: err } = await queryDetailedProfiles(supabase)
+    .eq("onboarded", true)
     .order("id", { ascending: true });
 
   if (err) throw error(500, err.message);


### PR DESCRIPTION
This pull request fixes the 500 error code occuring in the user explore page because of the presence on non onboarded users in it. They are now filtered out