### PR TITLE
Fix the explore page search bar

### DIFF
--- a/src/routes/(public)/explore/cubes/+page.svelte
+++ b/src/routes/(public)/explore/cubes/+page.svelte
@@ -167,7 +167,7 @@
         ($params.stick === undefined || c.stickered === $params.stick) &&
         ($params.smart === undefined || c.smart === $params.smart) &&
         // Text search on combined name
-        c.name.includes($params.q.toLowerCase())
+        c.name.toLowerCase().trim().includes($params.q.toLowerCase())
     );
   });
 


### PR DESCRIPTION
This pull request trimmed and puts to lowercase the cube name to fix the case sensitive search bar in the cube explore page