### PR TITLE
Add visual indication if missing data in the cube detail page

### DIFF
--- a/src/lib/contextKeys.ts
+++ b/src/lib/contextKeys.ts
@@ -1,0 +1,7 @@
+/**
+ * Context keys shared across the CubeIndex frontend.
+ *
+ * Using a central module prevents mismatched string literals and keeps inter-component
+ * communication predictable.
+ */
+export const CUBE_REPORT_CONTEXT_KEY = "cube-report" as const;

--- a/src/routes/(public)/explore/cubes/[slug]/+layout.svelte
+++ b/src/routes/(public)/explore/cubes/[slug]/+layout.svelte
@@ -1,15 +1,17 @@
 <script lang="ts">
   import type { LayoutProps } from "./$types";
-  import CubeVersionType from "$lib/components/cube/cubeVersionType.svelte";
-  import AddToCollectionButton from "$lib/components/misc/addToCollectionButton.svelte";
-  import RateCubeButton from "$lib/components/misc/rateCubeButton.svelte";
-  import ShareButton from "$lib/components/misc/shareButton.svelte";
-  import { page } from "$app/state";
-  import Report from "$lib/components/report/report.svelte";
-  import AddCube from "$lib/components/cube/addCube.svelte";
-  import { SsgoiTransition } from "@ssgoi/svelte";
-  import RateCube from "$lib/components/rating/rateCube.svelte";
-  import StarRating from "$lib/components/rating/starRating.svelte";
+  import { setContext } from "svelte";
+	import CubeVersionType from "$lib/components/cube/cubeVersionType.svelte";
+	import AddToCollectionButton from "$lib/components/misc/addToCollectionButton.svelte";
+	import RateCubeButton from "$lib/components/misc/rateCubeButton.svelte";
+	import ShareButton from "$lib/components/misc/shareButton.svelte";
+	import { CUBE_REPORT_CONTEXT_KEY } from "$lib/contextKeys";
+	import { page } from "$app/state";
+	import Report from "$lib/components/report/report.svelte";
+	import AddCube from "$lib/components/cube/addCube.svelte";
+	import { SsgoiTransition } from "@ssgoi/svelte";
+	import RateCube from "$lib/components/rating/rateCube.svelte";
+	import StarRating from "$lib/components/rating/starRating.svelte";
 
   let { data, children }: LayoutProps = $props();
   let { cube, user, meta, sameSeries, relatedCube, cubeTrims, features } =
@@ -29,6 +31,12 @@
   function toggleOpenReport() {
     openReport = !openReport;
   }
+
+	function openReportModal() {
+		openReport = true;
+	}
+
+	setContext(CUBE_REPORT_CONTEXT_KEY, openReportModal);
 
   // Derive the active tab from the URL so it stays in sync on navigation
   const currentTab = $derived.by(() => {
@@ -382,7 +390,7 @@
 
 {#if openReport}
   <Report
-    onCancel={() => (openReport = !openReport)}
+    onCancel={() => (openReport = false)}
     reportType="cube"
     reported={cube.slug}
     reporLabel="the {cube.series} {cube.model} {cube.version_name}"


### PR DESCRIPTION
This pull request adds visual indication if the cube is missing data :
<img width="875" height="550" alt="image" src="https://github.com/user-attachments/assets/1c20d588-72de-471c-8b63-41f140d92f2f" />
