### PR TITLE
Allow avatar image replacement during signup

### DIFF
--- a/src/routes/(auth)/auth/signup/+page.server.ts
+++ b/src/routes/(auth)/auth/signup/+page.server.ts
@@ -110,6 +110,7 @@ export const actions: Actions = {
       const { error: upErr } = await supabase.storage
         .from("avatars")
         .upload(path, processed, {
+          upsert: true,
           contentType: "image/webp", // fixed, known good
           cacheControl: "public, max-age=31536000, immutable",
         });


### PR DESCRIPTION
## Summary
- allow signup profile avatar uploads to overwrite an existing file by enabling Supabase storage upserts

## Testing
- npm run test *(fails: existing Vitest suite cannot find global expect when using @testing-library/jest-dom)*
- npm run check *(fails: repository missing environment bindings and generated $types for API routes)*

------
https://chatgpt.com/codex/tasks/task_e_68cc5b1433a8832c8c10f12a368006f6