### PR TITLE
Handle missing full name metadata in signup profile sync

### DIFF
--- a/src/routes/(auth)/auth/signup/+page.server.ts
+++ b/src/routes/(auth)/auth/signup/+page.server.ts
@@ -177,12 +177,15 @@ export const actions: Actions = {
       );
     }
 
+    const metadataDisplayName =
+      user.user_metadata?.full_name?.trim() || undefined;
+
     const payload = {
       email: user.email || "",
       display_name:
         display_name ??
         username ??
-        user.user_metadata.full_name.trim() ??
+        metadataDisplayName ??
         user.email?.split("@")[0] ??
         "User",
     };


### PR DESCRIPTION
## Summary
- add a null-safe metadata fallback when building the Brevo sync payload during signup
- keep the display name fallback order of username, metadata, email prefix, then a default label

## Testing
- npm run build *(fails: `PUBLIC_DEPLOYMENT_CHANNEL` import missing in build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc5b3d3ec4832c9abff0c3fb0c40d4