### PR TITLE
fix: close mobile profile menu when tapping outside

### DIFF
--- a/src/lib/components/layout/navbar.svelte
+++ b/src/lib/components/layout/navbar.svelte
@@ -174,6 +174,19 @@
     return () => window.removeEventListener("scroll", onScroll);
   });
 
+  // Close mobile user menu when clicking outside
+  let mobileUserMenuRef = $state<HTMLDivElement | null>(null);
+  $effect(() => {
+    if (!mobileUserMenuOpen) return;
+    function handleClickOutside(event: MouseEvent) {
+      if (mobileUserMenuRef && !mobileUserMenuRef.contains(event.target as Node)) {
+        mobileUserMenuOpen = false;
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  });
+
   // Ensure navbar shows when menus open/close
   $effect(() => {
     if (isOpen || exploreOpen) hideNav = false;
@@ -364,7 +377,7 @@
       </nav>
 
       {#if profile}
-        <div class="relative md:hidden">
+        <div class="relative md:hidden" bind:this={mobileUserMenuRef}>
           <button
             type="button"
             class="btn btn-ghost btn-circle size-12 overflow-hidden border border-base-300"


### PR DESCRIPTION
## Summary

Fixes #173

The mobile user profile menu (triggered by tapping the avatar in the top-right corner) had no click-outside handler. Tapping anywhere outside the open menu had no effect — users had to tap the avatar button again to close it, which is unintuitive.

## Root cause

The `mobileUserMenuOpen` state was only toggled by the avatar button's `onclick` handler. There was no mechanism to detect clicks outside the menu container.

## Fix

Added a reactive `$effect` in `navbar.svelte` that:
1. Attaches a `mousedown` listener on the document **only while the menu is open** (early return when closed)
2. Checks if the click target is outside the menu container (tracked via `bind:this={mobileUserMenuRef}`)
3. Sets `mobileUserMenuOpen = false` if the click is outside
4. Cleans up the event listener automatically when the menu closes or the component unmounts (Svelte $effect cleanup)

## Files changed

- `src/lib/components/layout/navbar.svelte` — added `mobileUserMenuRef` binding and click-outside $effect

## Testing

1. On a mobile viewport (or devtools mobile emulation), log in and tap your profile picture
2. The menu opens — tap anywhere in the red area outside the menu
3. The menu should close