### PR TITLE
fix: build failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ src/lib/paraglide
 
 # VSCode
 .vscode
+
+# Zed
+.zed

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   publish = "build"
-  command = "pnpm run build"
+  command = "npm run build"
 
 [[_redirects]]
   from = "/sitemap.xml"

--- a/package.json
+++ b/package.json
@@ -73,5 +73,8 @@
     "type-fest": "^5.7.0",
     "valibot": "^1.2.0"
   },
-  "overrides": {}
+  "overrides": {
+    "@tailwindcss/vite": "^4.1.8",
+    "rollup": "4.61.1"
+  }
 }


### PR DESCRIPTION
This pull request fixes this specific issue:
```
src/routes/(public)/explore/cubes/+page.svelte (108:38): Expected ',', got '?' (Note that you need plugins to import files that are not JavaScript)

106:   function uniqueSorted<T>(
107:     values: (T | null | undefined)[],
108:     compareFn?: (a: T, b: T) => number,
                                           ^
109:   ): T[] {
110:     return Array.from(new Set(values.filter((v): v is T => v != null))).sort(

    at getRollupError (file:///node_modules/rollup/dist/es/shared/parseAst.js:317:41)
    at ParseError.initialise (file:///node_modules/rollup/dist/es/shared/node-entry.js:14814:28)
    at convertNode (file:///node_modules/rollup/dist/es/shared/node-entry.js:16790:10)
    at convertProgram (file:///node_modules/rollup/dist/es/shared/node-entry.js:16026:12)
    at Module.setSource (file:///node_modules/rollup/dist/es/shared/node-entry.js:17769:24)
    at async ModuleLoader.addModuleSource (file:///node_modules/rollup/dist/es/shared/node-entry.js:21946:13)
```
which occurred when running `npm run build` by overriding the `@tailscalecss/vite` and `rollup` packages that were the cause of the issue.

I will need to look back into this to not stay on a obselete version of these packages.