### PR TITLE
Fix cube grid layout

### DIFF
--- a/src/lib/components/cube/cubeCard.svelte
+++ b/src/lib/components/cube/cubeCard.svelte
@@ -59,14 +59,14 @@
 {/snippet}
 
 {#snippet content()}
-  <div class="mt-4 flex gap-2">
+  <div class="mt-4 grid grid-cols-[repeat(auto-fit,minmax(10.5rem,1fr))] gap-4">
     {#if showAddButton}
       <AddToCollectionButton
         onClick={() => {
           openAddCard = !openAddCard;
         }}
         {alreadyAdded}
-        addClass="flex-1"
+        addClass="w-full"
       />
     {/if}
     {#if showRateButton}
@@ -74,7 +74,7 @@
         onClick={() => {
           openRateCard = !openRateCard;
         }}
-        addClass="flex-1"
+        addClass="w-full"
       />
     {/if}
   </div>

--- a/src/lib/components/cube/cubeCardSkeleton.svelte
+++ b/src/lib/components/cube/cubeCardSkeleton.svelte
@@ -40,7 +40,7 @@
 </svelte:head>
 
 <div
-  class="relative bg-base-200 border border-base-300 rounded-2xl shadow-lg overflow-hidden hover:shadow-xl transition flex flex-col h-full"
+  class="relative bg-base-200 border border-base-300 rounded-2xl shadow-lg overflow-hidden flex flex-col h-full"
 >
   {@render top?.()}
   <a href={resolve("/(public)/explore/cubes/[slug]", { slug: cube.slug })}>

--- a/src/lib/types/database-generated.types.ts
+++ b/src/lib/types/database-generated.types.ts
@@ -44,8 +44,7 @@ export type Database = {
           approved: boolean;
           brand: string | null;
           category:
-            | Database["public"]["Enums"]["accessories_categories"]
-            | null;
+            Database["public"]["Enums"]["accessories_categories"] | null;
           compatibility: string | null;
           created_at: string;
           discontinued: boolean;
@@ -61,8 +60,7 @@ export type Database = {
           approved?: boolean;
           brand?: string | null;
           category?:
-            | Database["public"]["Enums"]["accessories_categories"]
-            | null;
+            Database["public"]["Enums"]["accessories_categories"] | null;
           compatibility?: string | null;
           created_at?: string;
           discontinued?: boolean;
@@ -78,8 +76,7 @@ export type Database = {
           approved?: boolean;
           brand?: string | null;
           category?:
-            | Database["public"]["Enums"]["accessories_categories"]
-            | null;
+            Database["public"]["Enums"]["accessories_categories"] | null;
           compatibility?: string | null;
           created_at?: string;
           discontinued?: boolean;
@@ -96,8 +93,7 @@ export type Database = {
       achievements: {
         Row: {
           category:
-            | Database["public"]["Enums"]["achievements_categories"]
-            | null;
+            Database["public"]["Enums"]["achievements_categories"] | null;
           created_at: string;
           description: string;
           evolutive: boolean;
@@ -117,8 +113,7 @@ export type Database = {
         };
         Insert: {
           category?:
-            | Database["public"]["Enums"]["achievements_categories"]
-            | null;
+            Database["public"]["Enums"]["achievements_categories"] | null;
           created_at?: string;
           description: string;
           evolutive?: boolean;
@@ -138,8 +133,7 @@ export type Database = {
         };
         Update: {
           category?:
-            | Database["public"]["Enums"]["achievements_categories"]
-            | null;
+            Database["public"]["Enums"]["achievements_categories"] | null;
           created_at?: string;
           description?: string;
           evolutive?: boolean;
@@ -418,8 +412,7 @@ export type Database = {
           sub_type: Database["public"]["Enums"]["cubes_subtypes"] | null;
           submitted_by_id: string;
           surface_finish:
-            | Database["public"]["Enums"]["cube_surface_finishes"]
-            | null;
+            Database["public"]["Enums"]["cube_surface_finishes"] | null;
           type: string;
           updated_at: string;
           verified_at: string | null;
@@ -446,8 +439,7 @@ export type Database = {
           sub_type?: Database["public"]["Enums"]["cubes_subtypes"] | null;
           submitted_by_id?: string;
           surface_finish?:
-            | Database["public"]["Enums"]["cube_surface_finishes"]
-            | null;
+            Database["public"]["Enums"]["cube_surface_finishes"] | null;
           type: string;
           updated_at?: string;
           verified_at?: string | null;
@@ -474,8 +466,7 @@ export type Database = {
           sub_type?: Database["public"]["Enums"]["cubes_subtypes"] | null;
           submitted_by_id?: string;
           surface_finish?:
-            | Database["public"]["Enums"]["cube_surface_finishes"]
-            | null;
+            Database["public"]["Enums"]["cube_surface_finishes"] | null;
           type?: string;
           updated_at?: string;
           verified_at?: string | null;
@@ -1702,8 +1693,7 @@ export type Database = {
       v_achievement_rarity: {
         Row: {
           category:
-            | Database["public"]["Enums"]["achievements_categories"]
-            | null;
+            Database["public"]["Enums"]["achievements_categories"] | null;
           created_at: string | null;
           description: string | null;
           hidden: boolean | null;
@@ -1768,8 +1758,7 @@ export type Database = {
           sub_type: Database["public"]["Enums"]["cubes_subtypes"] | null;
           submitted_by_id: string | null;
           surface_finish:
-            | Database["public"]["Enums"]["cube_surface_finishes"]
-            | null;
+            Database["public"]["Enums"]["cube_surface_finishes"] | null;
           type: string | null;
           updated_at: string | null;
           verified_at: string | null;
@@ -2127,20 +2116,11 @@ export type Database = {
         | "Stand";
       achievements_categories: "Website" | "Quantity";
       "badge-rarity":
-        | "Special"
-        | "Legendary"
-        | "Mythic"
-        | "Epic"
-        | "Rare"
-        | "Common";
+        "Special" | "Legendary" | "Mythic" | "Epic" | "Rare" | "Common";
       cube_review_status: "published" | "draft" | "hidden";
       cube_scrap_runs_status: "queued" | "done" | "running" | "failed";
       cube_surface_finish:
-        | "Matte"
-        | "Frosted"
-        | "UV Coated"
-        | "Glossy"
-        | "Sculpted";
+        "Matte" | "Frosted" | "UV Coated" | "Glossy" | "Sculpted";
       cube_surface_finishes: "Frosted" | "UV Coated" | "Glossy" | "Sculpted";
       cube_version_type: "Base" | "Trim" | "Limited";
       cubes_subtypes:
@@ -2185,13 +2165,7 @@ export type Database = {
       staff_actions: "INSERT" | "UPDATE" | "DELETE";
       submission_status: "Approved" | "Rejected" | "Pending";
       user_cube_condition:
-        | "New in box"
-        | "New"
-        | "Good"
-        | "Fair"
-        | "Worn"
-        | "Poor"
-        | "Broken";
+        "New in box" | "New" | "Good" | "Fair" | "Worn" | "Poor" | "Broken";
       user_cube_status: "Owned" | "Wishlist" | "Loaned" | "Borrowed" | "Lost";
       users_roles:
         | "Admin"
@@ -2218,12 +2192,12 @@ export type Tables<
   DefaultSchemaTableNameOrOptions extends
     | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
     | { schema: keyof DatabaseWithoutInternals },
-  TableName extends DefaultSchemaTableNameOrOptions extends {
+  TableName extends (DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals;
   }
     ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
         DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
-    : never = never,
+    : never) = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals;
 }
@@ -2245,13 +2219,12 @@ export type Tables<
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
-    | { schema: keyof DatabaseWithoutInternals },
-  TableName extends DefaultSchemaTableNameOrOptions extends {
+    keyof DefaultSchema["Tables"] | { schema: keyof DatabaseWithoutInternals },
+  TableName extends (DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
-    : never = never,
+    : never) = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals;
 }
@@ -2270,13 +2243,12 @@ export type TablesInsert<
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
-    | { schema: keyof DatabaseWithoutInternals },
-  TableName extends DefaultSchemaTableNameOrOptions extends {
+    keyof DefaultSchema["Tables"] | { schema: keyof DatabaseWithoutInternals },
+  TableName extends (DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
-    : never = never,
+    : never) = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals;
 }
@@ -2295,13 +2267,12 @@ export type TablesUpdate<
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
-    | keyof DefaultSchema["Enums"]
-    | { schema: keyof DatabaseWithoutInternals },
-  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    keyof DefaultSchema["Enums"] | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends (DefaultSchemaEnumNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
-    : never = never,
+    : never) = never,
 > = DefaultSchemaEnumNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals;
 }
@@ -2314,11 +2285,11 @@ export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
     | keyof DefaultSchema["CompositeTypes"]
     | { schema: keyof DatabaseWithoutInternals },
-  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+  CompositeTypeName extends (PublicCompositeTypeNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
-    : never = never,
+    : never) = never,
 > = PublicCompositeTypeNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals;
 }

--- a/src/lib/types/database.types.ts
+++ b/src/lib/types/database.types.ts
@@ -49,8 +49,7 @@ interface DetailedCubeModels {
   sub_type: DatabaseGenerated["public"]["Enums"]["cubes_subtypes"] | null;
   submitted_by_id: string;
   surface_finish:
-    | DatabaseGenerated["public"]["Enums"]["cube_surface_finishes"]
-    | null;
+    DatabaseGenerated["public"]["Enums"]["cube_surface_finishes"] | null;
   type: string;
   updated_at: string;
   verified_at: string | null;
@@ -127,12 +126,12 @@ export type Tables<
   DefaultSchemaTableNameOrOptions extends
     | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
     | { schema: keyof DatabaseWithoutInternals },
-  TableName extends DefaultSchemaTableNameOrOptions extends {
+  TableName extends (DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals;
   }
     ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
         DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
-    : never = never,
+    : never) = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals;
 }
@@ -154,13 +153,12 @@ export type Tables<
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
-    | { schema: keyof DatabaseWithoutInternals },
-  TableName extends DefaultSchemaTableNameOrOptions extends {
+    keyof DefaultSchema["Tables"] | { schema: keyof DatabaseWithoutInternals },
+  TableName extends (DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
-    : never = never,
+    : never) = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals;
 }
@@ -179,13 +177,12 @@ export type TablesInsert<
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
-    | { schema: keyof DatabaseWithoutInternals },
-  TableName extends DefaultSchemaTableNameOrOptions extends {
+    keyof DefaultSchema["Tables"] | { schema: keyof DatabaseWithoutInternals },
+  TableName extends (DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
-    : never = never,
+    : never) = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals;
 }
@@ -204,13 +201,12 @@ export type TablesUpdate<
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
-    | keyof DefaultSchema["Enums"]
-    | { schema: keyof DatabaseWithoutInternals },
-  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    keyof DefaultSchema["Enums"] | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends (DefaultSchemaEnumNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
-    : never = never,
+    : never) = never,
 > = DefaultSchemaEnumNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals;
 }
@@ -223,11 +219,11 @@ export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
     | keyof DefaultSchema["CompositeTypes"]
     | { schema: keyof DatabaseWithoutInternals },
-  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+  CompositeTypeName extends (PublicCompositeTypeNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
-    : never = never,
+    : never) = never,
 > = PublicCompositeTypeNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals;
 }

--- a/src/routes/(auth)/auth/signup/+page.server.ts
+++ b/src/routes/(auth)/auth/signup/+page.server.ts
@@ -10,9 +10,7 @@ import { resolve } from "$app/paths";
 
 export const load: PageServerLoad = async ({ url }) => {
   const step = (url.searchParams.get("step") ?? "account") as
-    | "account"
-    | "survey"
-    | "done";
+    "account" | "survey" | "done";
 
   return {
     step,

--- a/src/routes/(public)/explore/cubes/+page.svelte
+++ b/src/routes/(public)/explore/cubes/+page.svelte
@@ -504,7 +504,7 @@
         <Pagination bind:currentPage={params.page.current} {totalPages} />
 
         <!-- Display paginated cubes -->
-        <div class="columns-3 my-10">
+        <div class="columns-1 sm:columns-2 md:columns-3 my-10">
           {#if paginatedCubes.length > 0}
             {#each paginatedCubes as cube, index (index)}
               {#key paginatedCubes}

--- a/src/routes/(public)/explore/cubes/+page.svelte
+++ b/src/routes/(public)/explore/cubes/+page.svelte
@@ -501,26 +501,26 @@
         </div>
 
         <!-- Pagination at top -->
-        <div class="mb-10">
-          <Pagination bind:currentPage={params.page.current} {totalPages} />
-        </div>
+        <Pagination bind:currentPage={params.page.current} {totalPages} />
 
         <!-- Display paginated cubes -->
-        <div class="grid grid-cols-[repeat(auto-fill,minmax(310px,1fr))] gap-8">
+        <div class="columns-3 my-10">
           {#if paginatedCubes.length > 0}
             {#each paginatedCubes as cube, index (index)}
               {#key paginatedCubes}
                 {@const userCubeDetail = userCubes?.find(
                   (uc) => uc.cube === cube.slug,
                 )}
-                <CubeCard
-                  {cube}
-                  showAddButton={true}
-                  showRateButton={true}
-                  showDetailsButton={true}
-                  alreadyAdded={userCubeDetail !== undefined}
-                  {userCubeDetail}
-                />
+                <div class="mb-4">
+                  <CubeCard
+                    {cube}
+                    showAddButton={true}
+                    showRateButton={true}
+                    showDetailsButton={true}
+                    alreadyAdded={userCubeDetail !== undefined}
+                    {userCubeDetail}
+                  />
+                </div>
               {/key}
             {/each}
           {:else}
@@ -558,9 +558,7 @@
         </div>
 
         <!-- Pagination at bottom -->
-        <div class="mt-10">
-          <Pagination bind:currentPage={params.page.current} {totalPages} />
-        </div>
+        <Pagination bind:currentPage={params.page.current} {totalPages} />
       </div>
     </div>
   </div>

--- a/src/routes/(public)/explore/cubes/+page.svelte
+++ b/src/routes/(public)/explore/cubes/+page.svelte
@@ -511,7 +511,7 @@
                 {@const userCubeDetail = userCubes?.find(
                   (uc) => uc.cube === cube.slug,
                 )}
-                <div class="mb-4">
+                <div class="mb-4 break-inside-avoid">
                   <CubeCard
                     {cube}
                     showAddButton={true}

--- a/src/routes/(public)/explore/cubes/[slug]/price/+page.svelte
+++ b/src/routes/(public)/explore/cubes/[slug]/price/+page.svelte
@@ -43,8 +43,7 @@
       return {
         label: row.vendor_name,
         data: labels.map((date) => priceByDate.get(date) ?? null) as (
-          | number
-          | null
+          number | null
         )[], // null makes a gap
         spanGaps: true,
       };

--- a/src/routes/(public)/user/[username]/+page.svelte
+++ b/src/routes/(public)/user/[username]/+page.svelte
@@ -259,16 +259,18 @@
       </div>
 
       {#if user_cubes && user_cubes.length > 0}
-        <ul class="grid grid-cols-1 gap-5 sm:grid-cols-2 md:grid-cols-3">
+        <ul class="columns-1 sm:columns-2 md:columns-3">
           {#each paginatedCubes as row (row.cube_model?.slug)}
-            <UserCubeCard
-              mode={edit ? "edit" : "view"}
-              cube={row.cube_model}
-              user_details={row}
-              user_rating={user_cube_ratings.find(
-                (ucr) => ucr.cube_slug === row.cube_model?.slug,
-              )?.rating ?? 0}
-            />
+            <div class="mb-4">
+              <UserCubeCard
+                mode={edit ? "edit" : "view"}
+                cube={row.cube_model}
+                user_details={row}
+                user_rating={user_cube_ratings.find(
+                  (ucr) => ucr.cube_slug === row.cube_model?.slug,
+                )?.rating ?? 0}
+              />
+            </div>
           {:else}
             <!-- No results state -->
             <div

--- a/src/routes/(public)/user/[username]/+page.svelte
+++ b/src/routes/(public)/user/[username]/+page.svelte
@@ -261,7 +261,7 @@
       {#if user_cubes && user_cubes.length > 0}
         <ul class="columns-1 sm:columns-2 md:columns-3">
           {#each paginatedCubes as row (row.cube_model?.slug)}
-            <div class="mb-4">
+            <div class="mb-4 break-inside-avoid">
               <UserCubeCard
                 mode={edit ? "edit" : "view"}
                 cube={row.cube_model}


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### What's being changed (if available, include any code snippets, screenshots, or gifs):
Made the cube explore page and user cube collection page display the cube cards in a masonry grid and fixed the action buttons in the cube card to be more responsive

### Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated cube listings and collections with responsive multi-column layouts.
  * Improved spacing around cube cards and pagination controls.
  * Adjusted card action buttons for full-width presentation.
  * Removed hover shadows from cube card placeholders.
  * Prevented cards from splitting across columns for a cleaner layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->